### PR TITLE
Add launcher batch helper pause on errors

### DIFF
--- a/src/briefcase/__init__.py
+++ b/src/briefcase/__init__.py
@@ -1,0 +1,3 @@
+"""Minimal stubs for Briefcase-style utilities used in tests."""
+
+__all__ = []

--- a/src/briefcase/platforms/__init__.py
+++ b/src/briefcase/platforms/__init__.py
@@ -1,0 +1,3 @@
+"""Platform-specific helpers for Briefcase-style tooling."""
+
+__all__ = []

--- a/src/briefcase/platforms/windows/__init__.py
+++ b/src/briefcase/platforms/windows/__init__.py
@@ -1,0 +1,3 @@
+"""Windows-specific helpers for Briefcase-style tooling."""
+
+__all__ = []

--- a/src/briefcase/platforms/windows/msi/__init__.py
+++ b/src/briefcase/platforms/windows/msi/__init__.py
@@ -1,0 +1,5 @@
+"""MSI-specific helpers for Briefcase-style tooling."""
+
+from .create import _write_launcher_batch
+
+__all__ = ["_write_launcher_batch"]

--- a/src/briefcase/platforms/windows/msi/create.py
+++ b/src/briefcase/platforms/windows/msi/create.py
@@ -1,0 +1,56 @@
+"""Utilities for generating Windows launcher batch files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+
+def _write_launcher_batch(
+    executable: Path,
+    launcher_path: Path,
+    log_path: Path,
+) -> str:
+    """Write a Windows batch file used to launch an executable.
+
+    Parameters
+    ----------
+    executable:
+        Absolute path to the executable that should be invoked by the batch file.
+    launcher_path:
+        Destination path for the batch file that will be written.
+    log_path:
+        Path to the log file that receives stdout/stderr from the executable.
+    """
+    launcher_path.parent.mkdir(parents=True, exist_ok=True)
+
+    script = "\r\n".join(
+        line.rstrip()
+        for line in dedent(
+            f"""
+            @echo off
+            setlocal
+
+            set "APP_EXECUTABLE={executable}"
+            set "LOG_FILE={log_path}"
+
+            echo Launching %APP_EXECUTABLE% > "%LOG_FILE%"
+            "%APP_EXECUTABLE%" %* >> "%LOG_FILE%" 2>&1
+            set "EXIT_CODE=%ERRORLEVEL%"
+
+            if %EXIT_CODE% neq 0 (
+                echo Application exited with code %EXIT_CODE%.
+                echo Log file: %LOG_FILE%
+                if errorlevel 1 pause
+            )
+
+            exit /b %EXIT_CODE%
+            """
+        ).strip().splitlines()
+    ) + "\r\n"
+
+    launcher_path.write_text(script, encoding="utf-8")
+    return script
+
+
+__all__ = ["_write_launcher_batch"]


### PR DESCRIPTION
## Summary
- add minimal Briefcase-style stubs under `src/briefcase` for Windows MSI helpers
- implement `_write_launcher_batch` so the launcher pauses on non-zero exits and reports the log file location

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d8eceb2b5c83308120545e2527f22c