### PR TITLE
Ensure PyInstaller collects Streamlit package

### DIFF
--- a/portable/build_portable_windows.py
+++ b/portable/build_portable_windows.py
@@ -44,6 +44,8 @@ def _pyinstaller_command() -> list[str]:
         "streamlit",
         "--collect-data",
         "streamlit",
+        "--collect-all",
+        "streamlit",
         "--hidden-import",
         "streamlit",
         "--collect-all",
@@ -53,7 +55,7 @@ def _pyinstaller_command() -> list[str]:
         str(app_entry),
     ]
 
-    streamlit_metadata_args = ["--collect-all", "streamlit"]
+    streamlit_metadata_args: list[str] = []
     try:
         importlib_metadata.distribution("streamlit")
     except Exception:


### PR DESCRIPTION
## Summary
- update the portable Windows build command to include --collect-all for the Streamlit package
- retain optional metadata collection when the distribution metadata is available

## Testing
- not run (Windows-only build process)

------
https://chatgpt.com/codex/tasks/task_e_68d91cb494308330a7229e51f33c5492