### PR TITLE
Handle missing Streamlit metadata in Windows portable build

### DIFF
--- a/portable/build_portable_windows.py
+++ b/portable/build_portable_windows.py
@@ -55,17 +55,20 @@ def _pyinstaller_command() -> list[str]:
         str(app_entry),
     ]
 
-    streamlit_metadata_args: list[str] = []
+    command.extend(_streamlit_metadata_args())
+
+    return command
+
+
+def _streamlit_metadata_args() -> list[str]:
+    """Return PyInstaller options for streamlit metadata when available."""
+
     try:
         importlib_metadata.distribution("streamlit")
     except Exception:
-        pass
-    else:
-        streamlit_metadata_args = ["--copy-metadata", "streamlit"]
+        return []
 
-    command.extend(streamlit_metadata_args)
-
-    return command
+    return ["--copy-metadata", "streamlit"]
 
 
 def build() -> Path:


### PR DESCRIPTION
## Summary
- import importlib.metadata (or backport) for compatibility in the Windows portable build script
- guard the streamlit metadata copy flag so it is only added when distribution metadata is present

## Testing
- not run (non-Windows environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9210d30e8833089fbaaad91c38aa1